### PR TITLE
Map versioned gpt-5 models to base name

### DIFF
--- a/src/routes/openaiRoutes.js
+++ b/src/routes/openaiRoutes.js
@@ -67,7 +67,12 @@ router.post('/responses', authenticateApiKey, async (req, res) => {
       null
 
     // 从请求体中提取模型和流式标志
-    const requestedModel = req.body?.model || null
+    let requestedModel = req.body?.model || null
+    // 如果模型名称以 gpt-5 开头，则映射为基础模型 gpt-5
+    if (requestedModel?.startsWith('gpt-5')) {
+      req.body.model = 'gpt-5'
+      requestedModel = 'gpt-5'
+    }
     const isStream = req.body?.stream !== false // 默认为流式（兼容现有行为）
 
     // 判断是否为 Codex CLI 的请求


### PR DESCRIPTION
## Summary
- Normalize gpt-5 model names that include a version suffix when forwarding OpenAI requests by remapping them to the base `gpt-5`

## Testing
- `npm test` *(fails: No tests found, exiting with code 1)*
- `npm run lint:check` *(fails: no-unused-vars in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_689af0ec37648326ab4307682c5c6d21